### PR TITLE
Don't set /SUBSYSTEM:WINDOWS in librarian options

### DIFF
--- a/mmh.vcxproj
+++ b/mmh.vcxproj
@@ -131,9 +131,7 @@
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
     </ClCompile>
-    <Lib>
-      <SubSystem>Windows</SubSystem>
-    </Lib>
+    <Lib />
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -151,9 +149,7 @@
       <ConformanceMode>true</ConformanceMode>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
     </ClCompile>
-    <Lib>
-      <SubSystem>Windows</SubSystem>
-    </Lib>
+    <Lib />
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="sha1.cpp" />


### PR DESCRIPTION
Based on the description of it (see https://docs.microsoft.com/en-gb/cpp/build/reference/managing-a-library?view=vs-2019 and https://docs.microsoft.com/en-gb/cpp/build/reference/subsystem-specify-subsystem?view=vs-2019), it seems a bit weird to set it on a library.

Additionally, removing it works around a problem when using Clang and llvm-lib.