### PR TITLE
Add string view and UTF-16 conversion helpers

### DIFF
--- a/string.cpp
+++ b/string.cpp
@@ -224,4 +224,17 @@ int compare_string_partial_case_insensitive(const char* str, const char* substr)
     }
 }
 
+std::wstring to_utf16(std::string_view utf8_value)
+{
+    const auto utf16_estimated_size = pfc::stringcvt::estimate_utf8_to_wide(utf8_value.data(), utf8_value.size());
+    std::wstring utf16_value;
+    utf16_value.resize(utf16_estimated_size);
+
+    const auto utf16_actual_size = pfc::stringcvt::convert_utf8_to_wide(
+        utf16_value.data(), utf16_estimated_size, utf8_value.data(), utf8_value.size());
+    utf16_value.resize(utf16_actual_size);
+
+    return utf16_value;
+}
+
 } // namespace mmh

--- a/string.h
+++ b/string.h
@@ -127,4 +127,14 @@ int64_t strtol64_n(const TChar* p_val, unsigned p_val_length, unsigned base = 10
 {
     return strtol_n<TChar, int64_t>(p_val, p_val_length, base);
 }
+
+template <typename String>
+requires requires(String value) { std::string_view(value.get_ptr(), value.length()); }
+std::string_view to_string_view(const String& value)
+{
+    return {value.get_ptr(), value.length()};
+}
+
+std::wstring to_utf16(std::string_view utf8_value);
+
 } // namespace mmh


### PR DESCRIPTION
This adds a function for creating an std::string_view from a pfc::string, and another for converting a UTF-8 string to UTF-16.