### PR TITLE
Add set_thread_description() functino

### DIFF
--- a/mmh.vcxproj
+++ b/mmh.vcxproj
@@ -176,6 +176,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="thread.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="algorithm.h" />

--- a/mmh.vcxproj.filters
+++ b/mmh.vcxproj.filters
@@ -4,6 +4,7 @@
     <ClCompile Include="osversion.cpp" />
     <ClCompile Include="stdafx.cpp" />
     <ClCompile Include="string.cpp" />
+    <ClCompile Include="thread.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="comptr.h" />

--- a/stdafx.h
+++ b/stdafx.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT _WIN32_WINNT_WIN10
+#endif
+
 #include <algorithm>
 #include <numeric>
 

--- a/thread.cpp
+++ b/thread.cpp
@@ -1,0 +1,20 @@
+#include "stdafx.h"
+
+namespace mmh {
+
+HRESULT set_thread_description(HANDLE thread, PCWSTR thread_description)
+{
+    const wil::unique_hmodule kernel_module(LoadLibraryExW(L"kernelbase.dll", nullptr, LOAD_LIBRARY_SAFE_CURRENT_DIRS));
+
+    if (!kernel_module)
+        return E_NOTIMPL;
+
+    const auto set_thread_description = GetProcAddressByFunctionDeclaration(kernel_module.get(), SetThreadDescription);
+
+    if (!set_thread_description)
+        return E_NOTIMPL;
+
+    return set_thread_description(thread, thread_description);
+}
+
+} // namespace mmh

--- a/thread.h
+++ b/thread.h
@@ -55,4 +55,6 @@ private:
     int m_priority;
 };
 
+HRESULT set_thread_description(HANDLE thread, PCWSTR thread_description);
+
 } // namespace mmh


### PR DESCRIPTION
This adds a small helper function for calling SetThreadDescription() on Windows 10 and newer (while failing gracefully on older versions of Windows).