### PR TITLE
Add helper for getting wil::ResultException message in UTF-8

### DIFF
--- a/mmh.vcxproj
+++ b/mmh.vcxproj
@@ -177,6 +177,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="thread.cpp" />
+    <ClCompile Include="wil.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="algorithm.h" />
@@ -188,8 +189,8 @@
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="string.h" />
     <ClInclude Include="thread.h" />
-    <ClInclude Include="type_traits.h" />
     <ClInclude Include="utility.h" />
+    <ClInclude Include="wil.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\pfc\pfc.vcxproj">

--- a/mmh.vcxproj.filters
+++ b/mmh.vcxproj.filters
@@ -5,6 +5,7 @@
     <ClCompile Include="stdafx.cpp" />
     <ClCompile Include="string.cpp" />
     <ClCompile Include="thread.cpp" />
+    <ClCompile Include="wil.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="comptr.h" />
@@ -16,8 +17,8 @@
     <ClInclude Include="algorithm.h" />
     <ClInclude Include="functional.h" />
     <ClInclude Include="pfc_interop.h" />
-    <ClInclude Include="type_traits.h" />
     <ClInclude Include="utility.h" />
+    <ClInclude Include="wil.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" />

--- a/stdafx.h
+++ b/stdafx.h
@@ -31,3 +31,4 @@
 #include "thread.h"
 #include "comptr.h"
 #include "utility.h"
+#include "wil.h"

--- a/wil.cpp
+++ b/wil.cpp
@@ -1,0 +1,18 @@
+#include "stdafx.h"
+
+namespace mmh {
+
+std::string get_caught_exception_message() noexcept
+{
+    try {
+        throw;
+    } catch (const wil::ResultException& result_exception) {
+        std::array<wchar_t, 2048> message;
+        (void)wil::GetFailureLogString(message.data(), message.size(), result_exception.GetFailureInfo());
+        return to_utf8(message.data());
+    } catch (const std::exception& exception) {
+        return exception.what();
+    }
+}
+
+} // namespace mmh

--- a/wil.h
+++ b/wil.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace mmh {
+
+std::string get_caught_exception_message() noexcept;
+
+}


### PR DESCRIPTION
This adds a helper function that the message from a caught `wil::ResultException` in UTF-8. (`wil::ResultException::what()` returns an ANSI string.)

If the caught exception is not a `wil::ResultException` but is still an `std::exception`, the helper function returns a copy of the string returned from `std::exception::what()` unmodified.